### PR TITLE
add Time Entries (fixed)

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[dev-packages]
+
+[packages]
+"e1839a8" = {path = ".", editable = true}
+
+[requires]
+python_version = "2.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,38 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "4ea06a97d861011c36a50ddc97277d6c215877a6683f4261e381562e11eb6742"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "2.7"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "e1839a8": {
+            "editable": true,
+            "path": "."
+        },
+        "iso8601": {
+            "hashes": [
+                "sha256:13858f8bfa913ccc0a08649598da7fe9d43197e546dd71f0aa7ad57c65196368"
+            ],
+            "version": "==0.1.8"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:8cfddb97667c2a9edaf28b506d2479f1b8dc0631cbdcd0ea8c8864def59c698b",
+                "sha256:f4ebc402e0ea5a87a3d42e300b76c292612d8467024f45f9858a8768f9fb6f6e"
+            ],
+            "version": "==2.0.1"
+        }
+    },
+    "develop": {}
+}

--- a/toggl/api.py
+++ b/toggl/api.py
@@ -12,9 +12,11 @@ class Api(object):
         from .workspace import WorkspaceList
         from .project import ProjectList
         from .reports import Reports
+        from .time_entries import TimeEntryList
 
         self.session = Session(self.BASE_URL, api_token)
         self.clients = ClientList(self)
         self.workspaces = WorkspaceList(self)
         self.projects = ProjectList(self)
         self.reports = Reports(api_token)
+        self.time_entries = TimeEntryList(self)

--- a/toggl/base.py
+++ b/toggl/base.py
@@ -67,7 +67,7 @@ class Object(object):
         self._update_attrs(kwargs)
 
     def _update_attrs(self, attrs):
-        for k, v in attrs.iteritems():
+        for k, v in iter(attrs.items()):
             try:
                 v = iso8601.parse_date(v)
                 attrs[k] = v

--- a/toggl/base.py
+++ b/toggl/base.py
@@ -13,6 +13,7 @@ class ObjectList(object):
             self.url = url
         self.api = api
         self._instance_cache = {}
+        self.filters = {}
 
     def list(self):
         return list(self)
@@ -24,8 +25,14 @@ class ObjectList(object):
         if not hasattr(self, '_datalist'):
             self._datalist = self.api.session.get(self.url)
 
-        for data in self._datalist:
-            yield self.get_instance_cls()(self.api, **data)
+        for data in self._datalist or []:
+            instance = self.get_instance_cls()(self.api, **data)
+            if any(self.filters):
+                for f in self.filters:
+                    if f in data and data[f] == self.filters[f]:
+                        yield instance
+            else:
+                yield instance
 
     def get(self, object_id):
         return self[object_id]

--- a/toggl/project.py
+++ b/toggl/project.py
@@ -26,6 +26,12 @@ class Project(Object):
         from .task import TaskList
         return TaskList(self.api, url='projects/%d/tasks' % self.id)
 
+    @cached_property
+    def time_entries(self):
+        from .time_entries import TimeEntryList
+        l = TimeEntryList(self.api, self.id)
+        return l
+
 
 class ProjectUserList(ObjectList):
     """A collection of Project-User mappings."""

--- a/toggl/session.py
+++ b/toggl/session.py
@@ -1,5 +1,5 @@
 import requests
-from urllib import urlencode
+from urllib.parse import urlencode
 import logging
 import json
 

--- a/toggl/session.py
+++ b/toggl/session.py
@@ -17,11 +17,11 @@ class Session(object):
 
     def _exec(self, method, url, *args, **kwargs):
         try:
-            log.debug("[req]: %s?%s [data: %s]" % (self.base_url + url,
-                urlencode(kwargs.get('params', {})), kwargs.get('data')))
+            # log.debug("[req]: %s?%s [data: %s]" % (self.base_url + url,
+            #     urlencode(kwargs.get('params', {})), kwargs.get('data')))
             response = method(self.base_url + url, *args, **kwargs)
-            log.debug("[resp %d]: %s" % (response.status_code,
-                repr(response.text)))
+            # log.debug("[resp %d]: %s" % (response.status_code,
+            #     repr(response.text)))
         except Exception as ex:
             log.debug("[err]: %s" % str(ex))
             raise Error(str(ex))

--- a/toggl/time_entries.py
+++ b/toggl/time_entries.py
@@ -1,4 +1,4 @@
-from urllib import urlencode
+from urllib.parse import urlencode
 from datetime import datetime
 
 from .base import ObjectList, Object, cached_property

--- a/toggl/time_entries.py
+++ b/toggl/time_entries.py
@@ -27,6 +27,9 @@ class TimeEntry(Object):
 
     """
 
+    def get_instance_url(self):
+        return "time_entries"
+
     @cached_property
     def name(self):
         return self.description

--- a/toggl/time_entries.py
+++ b/toggl/time_entries.py
@@ -1,4 +1,4 @@
-from urllib.parse import urlencode
+from urllib import urlencode
 import dateutil.parser as parser
 from datetime import datetime
 

--- a/toggl/time_entries.py
+++ b/toggl/time_entries.py
@@ -1,0 +1,43 @@
+from urllib.parse import urlencode
+import dateutil.parser as parser
+from datetime import datetime
+
+from .base import ObjectList, Object, cached_property
+
+__all__ = ['TimeEntryList', 'TimeEntry']
+
+
+class TimeEntryList(ObjectList):
+    """A collection of Time Entries."""
+
+    def __init__(self, api, project_id = None):
+        super(TimeEntryList, self).__init__(api)
+        if project_id:
+            self.filters = {
+                "pid": project_id
+            }
+
+    get_instance_cls = lambda self: TimeEntry
+    url = 'time_entries?%s' % urlencode({"start_date": "2017-01-01T00:00:00+02:00"})
+
+
+class TimeEntry(Object):
+    """TimeEntry object.
+
+    API doc: https://github.com/toggl/toggl_api_docs/blob/master/chapters/time_entries.md
+
+    """
+
+    @cached_property
+    def name(self):
+        return self.description
+
+    # @cached_property
+    # def project_users(self):
+    #     return ProjectUserList(self.api,
+    #         url='projects/%d/project_users' % self.id)
+
+    # @cached_property
+    # def tasks(self):
+    #     from .task import TaskList
+    #     return TaskList(self.api, url='projects/%d/tasks' % self.id)

--- a/toggl/time_entries.py
+++ b/toggl/time_entries.py
@@ -1,5 +1,4 @@
 from urllib import urlencode
-import dateutil.parser as parser
 from datetime import datetime
 
 from .base import ObjectList, Object, cached_property
@@ -18,7 +17,7 @@ class TimeEntryList(ObjectList):
             }
 
     get_instance_cls = lambda self: TimeEntry
-    url = 'time_entries?%s' % urlencode({"start_date": "2017-01-01T00:00:00+02:00"})
+    url = 'time_entries?%s' % urlencode({"start_date": "2017-01-01T00:00:00+00:00"})
 
 
 class TimeEntry(Object):
@@ -31,13 +30,3 @@ class TimeEntry(Object):
     @cached_property
     def name(self):
         return self.description
-
-    # @cached_property
-    # def project_users(self):
-    #     return ProjectUserList(self.api,
-    #         url='projects/%d/project_users' % self.id)
-
-    # @cached_property
-    # def tasks(self):
-    #     from .task import TaskList
-    #     return TaskList(self.api, url='projects/%d/tasks' % self.id)


### PR DESCRIPTION
Adding Time Entries per project.

It uses a filtering mechanism to get the time entries for each individual project. 

Fix: removed some artifacts and Python 2.7 incompatibilities that slipped through. 